### PR TITLE
docs: fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LambdaTest-Gradle-Tunnel
-![LambdaTest Logo](https://www.lambdatest.com/static/images/logo.svg)
+![LambdaTest Logo](https://www.lambdatest.com/resources/images/logos/logo.svg)
 
 ---
 


### PR DESCRIPTION
The LambdaTest logo link was broken.This PR fixes that.